### PR TITLE
Undefined names: Add missing imports in monitor.py

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -2,12 +2,15 @@ __all__ = ['Monitor', 'get_monitor_files', 'load_results']
 
 import gym
 from gym.core import Wrapper
+import os
 import time
+import uuid
 from glob import glob
 import csv
 import os.path as osp
 import json
 import numpy as np
+import pandas
 
 class Monitor(Wrapper):
     EXT = "monitor.csv"


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/openai/random-network-distillation on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./monitor.py:144:55: F821 undefined name 'uuid'
    mon_file = "/tmp/baselines-test-%s.monitor.csv" % uuid.uuid4()
                                                      ^
./monitor.py:160:20: F821 undefined name 'pandas'
    last_logline = pandas.read_csv(f, index_col=None)
                   ^
./monitor.py:163:5: F821 undefined name 'os'
    os.remove(mon_file)    ^
3     F821 undefined name 'uuid'
3
```